### PR TITLE
Fix: Update chdbits.yml definition

### DIFF
--- a/src/Jackett.Common/Definitions/chdbits.yml
+++ b/src/Jackett.Common/Definitions/chdbits.yml
@@ -6,8 +6,8 @@ language: zh-CN
 type: private
 encoding: UTF-8
 links:
-  - https://chdbits.co/
   - https://ptchdbits.co/
+  - https://chdbits.co/
 
 caps:
   categorymappings:
@@ -66,6 +66,8 @@ login:
   path: login.php
   method: form
   form: form[action="takelogin.php"]
+  headers:
+    user-agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"]
   captcha:
     type: image
     selector: img[alt="CAPTCHA"]
@@ -80,9 +82,12 @@ login:
   error:
     - selector: td.embedded:has(h2:contains("失败"))
     - selector: td.embedded:has(h2:contains("failed"))
+    - selector: td.embedded:has(h2:contains("错误"))
+    - selector: td.embedded:has(h2:contains("error"))
+    - selector: font[color="red"]
   test:
     path: torrents.php
-    selector: a[href*="logout.php"]
+    selector: "#info_block,.userinfo,a[href*=\"logout\"],a[href*=\"userdetails\"]"
 
 download:
   selectors:


### PR DESCRIPTION
Update CHDBits indexer configuration:

1. Changes made:
   - Reordered domain URLs to prioritize ptchdbits.co
   - Added more login verification selectors
   - Added additional error detection selectors
   - Updated user-agent header

2. Reasons for changes:
   - ptchdbits.co domain is more stable and less likely to return 403 errors
   - Previous login verification was too strict and could fail even on successful logins
   - Added more comprehensive error detection for better troubleshooting
   - Added standard user-agent to improve site compatibility

3. Testing:
   - Verified login works with ptchdbits.co domain
   - Confirmed search functionality works
   - Tested with FlareSolverr enabled
   - Verified both domains remain accessible as fallback options

Note: These changes improve the reliability of the CHDBits indexer while maintaining compatibility with both domains.